### PR TITLE
Add confirmation for blacklist commands

### DIFF
--- a/bot/utils/__init__.py
+++ b/bot/utils/__init__.py
@@ -1,0 +1,1 @@
+from .callback_data import BlacklistConfirm

--- a/bot/utils/callback_data.py
+++ b/bot/utils/callback_data.py
@@ -1,0 +1,9 @@
+from aiogram.filters.callback_data import CallbackData
+
+
+class BlacklistConfirm(CallbackData, prefix="blconfirm"):
+    user_id: int
+    chat_id: int
+    message_id: int
+    revoke: int = 0
+    mark_spam: int = 0

--- a/database/repositories/message.py
+++ b/database/repositories/message.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import func, insert, update, select 
+from sqlalchemy import func, insert, update, select
 from sqlalchemy.sql.expression import and_
 
 from database.models import Message
@@ -38,18 +38,31 @@ class MessageRepository:
         query = select(Message).where(Message.user_id == user_id)
         result = await self.db.execute(query)
         return result.scalars().all()
-    
+
+    async def count_user_chats(self, user_id: int) -> int:
+        query = select(func.count(func.distinct(Message.chat_id))).where(Message.user_id == user_id)
+        result = await self.db.execute(query)
+        count = result.scalar()
+        return count or 0
+
+    async def count_user_messages(self, user_id: int) -> int:
+        query = select(func.count()).where(Message.user_id == user_id)
+        result = await self.db.execute(query)
+        count = result.scalar()
+        return count or 0
+
     async def is_first_message(self, chat_id: int, user_id: int) -> bool:
         query = select(func.count()).where(Message.user_id == user_id, Message.chat_id == chat_id)
         result = await self.db.execute(query)
         count = result.scalar()
         return count is not None and count > 0
-    
+
     async def is_similar_spam_message(self, message: str) -> bool:
         query = select(func.count()).where(Message.message == message, Message.spam == True)
         result = await self.db.execute(query)
         count = result.scalar()
         return count is not None and count > 0
+
 
 def get_message_repository(db: AsyncSession) -> MessageRepository:
     return MessageRepository(db)


### PR DESCRIPTION
## Summary
- ask for confirmation before `black` and `spam` commands run
- show stats on number of chats/messages from the target user
- handle callbacks that finalize blacklisting
- expose `BlacklistConfirm` callback data helper
- add message repository methods to count user activity

## Testing
- `black bot/handlers/moderation.py bot/utils/callback_data.py bot/utils/__init__.py database/repositories/message.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68887635dcc48322aabb96adc0df794a