### PR TITLE
Improve admin and moderation messages

### DIFF
--- a/app/presentation/telegram/handlers/admin.py
+++ b/app/presentation/telegram/handlers/admin.py
@@ -13,7 +13,7 @@ async def new_admin(message: types.Message, admin_repo: AdminRepository):
     target_user = message.reply_to_message.from_user
     if not await admin_repo.is_admin(target_user.id):
         await admin_repo.insert_admin(target_user.id)
-        await message.answer(f"Админ {await other.get_user_mention(target_user)} добавлен.")
+        await message.answer(f"Админ {await other.get_user_mention(target_user)} добавлен ✅")
     else:
         await message.answer(f"Админ {await other.get_user_mention(target_user)} уже есть в базе.")
     await message.delete()
@@ -24,7 +24,7 @@ async def delete_admin(message: types.Message, admin_repo: AdminRepository):
     target_user = message.reply_to_message.from_user
     if await admin_repo.is_admin(target_user.id):
         await admin_repo.delete_admin(target_user.id)
-        await message.answer(f"Админ {await other.get_user_mention(target_user)} удален.")
+        await message.answer(f"Админ {await other.get_user_mention(target_user)} удален ❌")
     else:
         await message.answer(f"Админ {await other.get_user_mention(target_user)} не является админом.")
     await message.delete()

--- a/app/presentation/telegram/handlers/moderation.py
+++ b/app/presentation/telegram/handlers/moderation.py
@@ -14,21 +14,21 @@ from app.infrastructure.db.repositories import ChatRepository, MessageRepository
 router = Router()
 
 
-def reply_required_error(message: types.Message, action: str) -> str:
-    """Returns a standard error message for missing reply."""
-    return f"Примените команду к сообщению человека, которого нужно {action}."
+def reply_required_error(action: str) -> str:
+    """Standard error when a command should be a reply."""
+    return f"Примените команду ответом на сообщение пользователя, которого нужно {action}. 🙏"
 
 
 def is_user_check_error() -> str:
-    """Returns a standard error message for invalid user check."""
-    return "Это не пользователь или что-то пошло не так."
+    """Standard error when target message does not contain a user."""
+    return "🚫 Это не пользователь или что-то пошло не так."
 
 
 @router.message(Command("mute", prefix="!/"))
 async def mute_user(message: types.Message, bot: Bot):
     # Ensure command is used as a reply
     if not message.reply_to_message:
-        await message.answer(reply_required_error(message, "замутить"))
+        await message.answer(reply_required_error("замутить"))
         await message.delete()
         return
 
@@ -85,7 +85,7 @@ async def mute_user(message: types.Message, bot: Bot):
 @router.message(Command("unmute", prefix="!/"))
 async def unmute_member(message: types.Message):
     if not message.reply_to_message:
-        await message.answer(reply_required_error(message, "размутить"))
+        await message.answer(reply_required_error("размутить"))
         await message.delete()
         return
 
@@ -114,7 +114,7 @@ async def unmute_member(message: types.Message):
 @router.message(Command("ban", prefix="!/"))
 async def ban_user(message: types.Message, bot: Bot):
     if not message.reply_to_message:
-        await message.answer(reply_required_error(message, "забанить"))
+        await message.answer(reply_required_error("забанить"))
         return
 
     if not message.reply_to_message.from_user:
@@ -135,7 +135,7 @@ async def ban_user(message: types.Message, bot: Bot):
 @router.message(Command("unban", prefix="!/"))
 async def unban_user(message: types.Message, bot: Bot):
     if not message.reply_to_message:
-        await message.answer(reply_required_error(message, "разбанить"))
+        await message.answer(reply_required_error("разбанить"))
         return
 
     if not message.reply_to_message.from_user:
@@ -156,7 +156,7 @@ async def unban_user(message: types.Message, bot: Bot):
 @router.message(Command("black", prefix="!/"))
 async def full_ban(message: types.Message, bot: Bot, message_repo: MessageRepository, db: AsyncSession):
     if not message.reply_to_message:
-        await message.answer(reply_required_error(message, "добавить в черный список"))
+        await message.answer(reply_required_error("добавить в черный список"))
         return
 
     if not message.reply_to_message.from_user:
@@ -195,7 +195,7 @@ async def full_ban(message: types.Message, bot: Bot, message_repo: MessageReposi
 @router.message(Command("spam", prefix="!/"))
 async def label_spam(message: types.Message, message_repo: MessageRepository, db: AsyncSession, bot: Bot):
     if not message.reply_to_message:
-        answer = await message.answer(reply_required_error(message, "пометить как спам"))
+        answer = await message.answer(reply_required_error("пометить как спам"))
         await message.delete()
         await other.sleep_and_delete(answer, 10)
         return

--- a/app/presentation/telegram/handlers/start.py
+++ b/app/presentation/telegram/handlers/start.py
@@ -12,13 +12,13 @@ router = Router()
 @router.message(Command("start", "help", prefix="/!"))
 async def start_private(message: types.Message):
     text = (
-        "<b>🤖Привет!</b>\n"
-        "Я модеририрую чаты по Чехии!\n\n"
-        "📚<b>Команды:</b>\n"
-        "/chats - список чатов\n"
-        "/contacts - контакты\n"
-        "/help - помощь\n"
-        "/report - пожаловаться (нужно переслать сообщение)\n"
+        "<b>🤖 Привет!</b>\n"
+        "Я модерирую чаты по Чехии!\n\n"
+        "📚 <b>Команды:</b>\n"
+        "• /chats - список чатов\n"
+        "• /contacts - контакты\n"
+        "• /help - помощь\n"
+        "• /report - пожаловаться (нужно переслать сообщение)\n"
     )
     builder = await buttons_service.get_contacts_buttons()
     bot_message = await message.answer(text, disable_web_page_preview=True, reply_markup=builder.as_markup())
@@ -37,7 +37,7 @@ async def get_chats(message: types.Message, db: AsyncSession):
 
 @router.message(Command("contacts", prefix="/!"))
 async def get_contacts(message: types.Message):
-    text = "📞 <b>Контакты:</b>\n\n" "📧 <b>Сотрудничество:</b> @czech_media_admin\n" "🧑🏿‍💻 <b>Dev:</b> @vsem_azamat"
+    text = "📞 <b>Контакты:</b>\n\n" "• 📧 <b>Сотрудничество:</b> @czech_media_admin\n" "• 🧑🏿‍💻 <b>Dev:</b> @vsem_azamat"
     bot_message = await message.answer(text)
     await message.delete()
     await other.sleep_and_delete(bot_message)

--- a/app/presentation/telegram/middlewares/admin.py
+++ b/app/presentation/telegram/middlewares/admin.py
@@ -7,12 +7,13 @@ from config import cnfg
 from app.infrastructure.db.repositories import AdminRepository
 
 
-async def you_are_not_admin(event: TelegramObject, text: str = "You are not an Admin.") -> None:
+async def you_are_not_admin(event: TelegramObject, text: str = "🚫 You are not an Admin.") -> None:
+    """Inform user that they are not an admin and remove helper messages."""
     if isinstance(event, types.Message):
-        asnwer = await event.answer(text)
-        event.delete()
+        answer = await event.answer(text)
+        await event.delete()
         await asyncio.sleep(5)
-        await asnwer.delete()
+        await answer.delete()
 
 
 class SuperAdminMiddleware(BaseMiddleware):

--- a/app/presentation/telegram/utils/other.py
+++ b/app/presentation/telegram/utils/other.py
@@ -6,21 +6,23 @@ from aiogram import types
 from typing import Union
 
 
-async def sleep_and_delete(message: types.Message, seconds: int = 60):
+async def sleep_and_delete(message: types.Message, seconds: int = 60) -> None:
+    """Delete a message after a short delay."""
     await asyncio.sleep(seconds)
     await message.delete()
 
 
 async def get_user_mention(user: types.User) -> str:
+    """Return mention markup for a user."""
     return user.mention_html()
 
 
 async def get_chat_mention(tg_object: Union[types.Message, types.Chat]) -> str:
+    """Return HTML link to a chat or its message."""
     chat_link = await get_chat_link(tg_object)
     if isinstance(tg_object, types.Message):
         return f'<a href="{chat_link}">{tg_object.chat.title}</a>'
-    else:
-        return f'<a href="{chat_link}">{tg_object.title}</a>'
+    return f'<a href="{chat_link}">{tg_object.title}</a>'
 
 
 async def get_message_mention(message: types.Message) -> str:
@@ -29,7 +31,7 @@ async def get_message_mention(message: types.Message) -> str:
 
 
 async def get_message_link(tg_object: Union[types.Message, types.Chat]) -> str:
-    # chat = objecys.chat
+    """Generate a direct link to a message."""
     if isinstance(tg_object, types.Message):
         chat = tg_object.chat
     else:
@@ -46,6 +48,7 @@ async def get_message_link(tg_object: Union[types.Message, types.Chat]) -> str:
 
 
 async def get_chat_link(tg_object: Union[types.Message, types.Chat]) -> str:
+    """Return a direct link to a chat."""
     if isinstance(tg_object, types.Message):
         chat = tg_object.chat
     else:
@@ -68,6 +71,7 @@ class MuteDuration:
 
 
 def calculate_mute_duration(message: str) -> MuteDuration:
+    """Parse /mute command and calculate mute duration."""
     command_parse = re.compile(r"(!mute|/mute) ?(\d+)? ?(m|h|d|w)?")
     parsed = command_parse.match(message)
 

--- a/app/presentation/telegram/utils/other.py
+++ b/app/presentation/telegram/utils/other.py
@@ -22,7 +22,8 @@ async def get_chat_mention(tg_object: Union[types.Message, types.Chat]) -> str:
     chat_link = await get_chat_link(tg_object)
     if isinstance(tg_object, types.Message):
         return f'<a href="{chat_link}">{tg_object.chat.title}</a>'
-    return f'<a href="{chat_link}">{tg_object.title}</a>'
+    else:
+        return f'<a href="{chat_link}">{tg_object.title}</a>'
 
 
 async def get_message_mention(message: types.Message) -> str:


### PR DESCRIPTION
## Summary
- clean up admin middleware helper
- tweak admin handler texts and add emojis
- clarify moderation utility messages
- polish /start and contact messages
- add docstrings in helper utilities

## Testing
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_6889caa394688322935d87e4aa59ca48