### PR TITLE
Add admin unblacklist command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ uv run -m pytest
 | `/ban` | Bans a user from the chat and adds to the blacklist. | ✅ | 👮 |
 | `/unban` | Unbans a user from the blacklist. | ✅ | 👮 |
 | `black` | Adds a user to the blacklist for all chats. | ✅ | 👮 |
+| `/blacklist` | Shows blacklisted users with unban buttons. | ✅ | 👮 |
 | `welcome` | Enables a welcome message for new chat members. | ✅ | 👮 |
 | `welcome <text>` | Changes the welcome message. | ✅ | 👮 |
 | `welcome -t <int>` | Changes the time for auto-deleting the welcome message. | 🚧 | 👮 |

--- a/app/infrastructure/db/repositories/user.py
+++ b/app/infrastructure/db/repositories/user.py
@@ -41,6 +41,10 @@ class UserRepository:
             await self.db.execute(insert(User).values(id=id_tg, blocked=True))
         await self.db.commit()
 
+    async def remove_from_blacklist(self, id_tg: int) -> None:
+        await self.db.execute(update(User).where(User.id == id_tg).values(blocked=False))
+        await self.db.commit()
+
 
 def get_user_repository(db: AsyncSession) -> UserRepository:
     return UserRepository(db)

--- a/app/presentation/telegram/handlers/moderation.py
+++ b/app/presentation/telegram/handlers/moderation.py
@@ -5,10 +5,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from typing import cast
 from app.presentation.telegram.logger import logger
-from app.presentation.telegram.utils import other, BlacklistConfirm
+from app.presentation.telegram.utils import other, BlacklistConfirm, UnblockUser
 from app.application.services import moderation as moderation_services
 from app.application.services import spam as spam_service
-from app.infrastructure.db.repositories import ChatRepository, MessageRepository
+from app.infrastructure.db.repositories import (
+    ChatRepository,
+    MessageRepository,
+    UserRepository,
+)
 
 
 router = Router()
@@ -276,4 +280,34 @@ async def process_blacklist_confirm(
 @router.callback_query(lambda c: c.data == "cancel_blacklist")
 async def process_blacklist_cancel(callback: types.CallbackQuery):
     await callback.message.edit_text("Действие отменено")
+    await callback.answer()
+
+
+@router.message(Command("blacklist", prefix="!/"))
+async def show_blacklist(message: types.Message, user_repo: UserRepository):
+    blocked_users = await user_repo.get_blocked_users()
+    if not blocked_users:
+        await message.answer("Чёрный список пуст")
+        await message.delete()
+        return
+
+    builder = InlineKeyboardBuilder()
+    for user in blocked_users:
+        title = user.username or user.first_name or str(user.id)
+        builder.button(text=title, callback_data=UnblockUser(user_id=user.id).pack())
+    builder.adjust(1)
+    await message.answer("<b>Чёрный список:</b>", reply_markup=builder.as_markup())
+    await message.delete()
+
+
+@router.callback_query(UnblockUser.filter())
+async def unblock_user_callback(
+    callback: types.CallbackQuery,
+    callback_data: UnblockUser,
+    bot: Bot,
+    db: AsyncSession,
+):
+    user_id = callback_data.user_id
+    await moderation_services.remove_from_blacklist(db, bot, user_id)
+    await callback.message.edit_text(f"Пользователь {user_id} разблокирован")
     await callback.answer()

--- a/app/presentation/telegram/handlers/start.py
+++ b/app/presentation/telegram/handlers/start.py
@@ -2,6 +2,8 @@ from aiogram import types, Router
 from aiogram.filters import Command
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from config import cnfg
+from app.infrastructure.db.repositories import AdminRepository
 from app.presentation.telegram.utils import other
 from app.application.services import buttons as buttons_service
 
@@ -10,7 +12,7 @@ router = Router()
 
 
 @router.message(Command("start", "help", prefix="/!"))
-async def start_private(message: types.Message):
+async def start_private(message: types.Message, admin_repo: AdminRepository):
     text = (
         "<b>🤖 Привет!</b>\n"
         "Я модерирую чаты по Чехии!\n\n"
@@ -20,8 +22,29 @@ async def start_private(message: types.Message):
         "• /help - помощь\n"
         "• /report - пожаловаться (нужно переслать сообщение)\n"
     )
+
+    is_admin = message.from_user.id in cnfg.SUPER_ADMINS or await admin_repo.is_admin(message.from_user.id)
+    if is_admin:
+        text += (
+            "\n\n<b>👮 Команды для админов:</b>\n"
+            "• /mute - замутить пользователя\n"
+            "• /unmute - размутить пользователя\n"
+            "• /ban - бан и добавить в ЧС\n"
+            "• /unban - убрать из ЧС\n"
+            "• /black - занести в ЧС всех чатов\n"
+            "• /blacklist - посмотреть ЧС\n"
+            "• /welcome <text> - изменить приветствие\n"
+            "• /admin - добавить админа (ответом)\n"
+            "• /unadmin - убрать админа (ответом)\n"
+            "• /json - получить JSON сообщения\n"
+        )
+
     builder = await buttons_service.get_contacts_buttons()
-    bot_message = await message.answer(text, disable_web_page_preview=True, reply_markup=builder.as_markup())
+    bot_message = await message.answer(
+        text,
+        disable_web_page_preview=True,
+        reply_markup=builder.as_markup(),
+    )
     await message.delete()
     await other.sleep_and_delete(bot_message)
 

--- a/app/presentation/telegram/utils/callback_data.py
+++ b/app/presentation/telegram/utils/callback_data.py
@@ -7,3 +7,7 @@ class BlacklistConfirm(CallbackData, prefix="blconfirm"):
     message_id: int
     revoke: int = 0
     mark_spam: int = 0
+
+
+class UnblockUser(CallbackData, prefix="unblock"):
+    user_id: int

--- a/tests/test_user_repository.py
+++ b/tests/test_user_repository.py
@@ -1,0 +1,15 @@
+import pytest
+from app.infrastructure.db.repositories.user import UserRepository
+
+
+@pytest.mark.asyncio
+async def test_add_and_remove_blacklist(session):
+    repo = UserRepository(session)
+    await repo.add_to_blacklist(123)
+    blocked = await repo.get_blocked_users()
+    assert len(blocked) == 1
+    assert blocked[0].id == 123
+
+    await repo.remove_from_blacklist(123)
+    blocked_after = await repo.get_blocked_users()
+    assert len(blocked_after) == 0


### PR DESCRIPTION
## Summary
- allow removing users from blacklist
- unban users across all chats via service
- add interactive `/blacklist` admin command
- document new command
- cover UserRepository blacklist operations
- show admin-only commands in `/help`

## Testing
- `ruff check tests`
- `uv run -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889d901398083229f3d827870aacb5e