### PR TITLE
Fix start command escaping

### DIFF
--- a/app/presentation/telegram/handlers/start.py
+++ b/app/presentation/telegram/handlers/start.py
@@ -33,7 +33,7 @@ async def start_private(message: types.Message, admin_repo: AdminRepository):
             "• /unban - убрать из ЧС\n"
             "• /black - занести в ЧС всех чатов\n"
             "• /blacklist - посмотреть ЧС\n"
-            "• /welcome <text> - изменить приветствие\n"
+            "• /welcome &lt;text&gt; - изменить приветствие\n"
             "• /admin - добавить админа (ответом)\n"
             "• /unadmin - убрать админа (ответом)\n"
             "• /json - получить JSON сообщения\n"


### PR DESCRIPTION
## Summary
- escape `<text>` in `/welcome` command description so Telegram accepts HTML

## Testing
- `ruff check tests`
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889df4e45d883229cddb15f67def4e6